### PR TITLE
GCC (at least >= 4.8) compilation fix

### DIFF
--- a/include/roboptim/core/manifold-map/decorator/problem-on-manifold.hh
+++ b/include/roboptim/core/manifold-map/decorator/problem-on-manifold.hh
@@ -40,6 +40,7 @@ namespace roboptim
       : manifold_(manifold)
     {}
 
+    template <typename Fake = void>
     mnf::Manifold& getManifold() const;
   };
 

--- a/include/roboptim/core/manifold-map/decorator/problem-on-manifold.hh
+++ b/include/roboptim/core/manifold-map/decorator/problem-on-manifold.hh
@@ -40,7 +40,6 @@ namespace roboptim
       : manifold_(manifold)
     {}
 
-    template<typename Fake>
     mnf::Manifold& getManifold() const;
   };
 

--- a/include/roboptim/core/manifold-map/decorator/problem-on-manifold.hxx
+++ b/include/roboptim/core/manifold-map/decorator/problem-on-manifold.hxx
@@ -34,7 +34,8 @@ namespace roboptim
   {
   }
 
-  mnf::Manifold& IsAProblemOnManifold::getManifold() const
+  template <>
+  mnf::Manifold& IsAProblemOnManifold::getManifold<void>() const
   {
     return this->manifold_;
   }

--- a/include/roboptim/core/manifold-map/decorator/problem-on-manifold.hxx
+++ b/include/roboptim/core/manifold-map/decorator/problem-on-manifold.hxx
@@ -34,7 +34,6 @@ namespace roboptim
   {
   }
 
-  template<typename Fake = void>
   mnf::Manifold& IsAProblemOnManifold::getManifold() const
   {
     return this->manifold_;

--- a/tests/problem-factory.cc
+++ b/tests/problem-factory.cc
@@ -332,7 +332,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(manifold_problem_factory_no_constraints, T, functi
   roboptim::ManifoldProblemFactory<problem_t> factory;
 
   roboptim::ProblemOnManifold<problem_t>* manifoldProblem;
-  BOOST_CHECK_THROW(manifoldProblem = factory.getProblem(), std::runtime_error);
+  BOOST_CHECK_THROW(manifoldProblem = factory.getProblem(); delete manifoldProblem, std::runtime_error);
 }
 
 BOOST_AUTO_TEST_SUITE_END ()


### PR DESCRIPTION
The idea is to fix the compilation fail created by [this](https://github.com/roboptim/roboptim-core-manifold/commit/7c76da57c2778d82c8cc62f03973b1dacc54aaed) commit.

A way to do it could be to remove the Fake template parameter in IsAProblemOnManifold interface, but we have to discuss it, especially because other projects may rely on this feature.
