### PR TITLE
Added a setter method to bound a manifold's value

### DIFF
--- a/include/roboptim/core/manifold-map/decorator/manifold-problem-factory.hh
+++ b/include/roboptim/core/manifold-map/decorator/manifold-problem-factory.hh
@@ -83,6 +83,12 @@ namespace roboptim
     template<class V, class W>
     void setObjective(DescriptiveWrapper<V, W>& descWrap, mnf::Manifold& instanceManifold);
 
+    /// \brief for a given elementary manifold, add bounds to its arguments
+    ///
+    /// \param manifold the elementary manifold to bound
+    /// \param bounds the list of bounds for each value of a point on this manifold
+    void addArgumentBounds(const mnf::Manifold& manifold, const typename U::function_t::intervals_t& bounds);
+
     /// \brief generate and return the described problem
     ProblemOnManifold<U>* getProblem();
 
@@ -92,6 +98,8 @@ namespace roboptim
   private:
     /// \brief elementary manifolds composing the global manifold of the problem
     std::map<long, const mnf::Manifold*> elementaryInstanceManifolds_;
+    /// \brief argument bounds for each elementary manifold
+    std::map<long, typename U::function_t::intervals_t> elementaryArgumentBounds_;
     /// \brief bounds and scaling for each constraint
     std::vector<std::pair<typename U::function_t::intervals_t, typename U::scaling_t>> boundsAndScaling_;
     /// \brief each std::function instantiate and add a constraint to the problem

--- a/include/roboptim/core/manifold-map/decorator/problem-on-manifold.hh
+++ b/include/roboptim/core/manifold-map/decorator/problem-on-manifold.hh
@@ -40,8 +40,8 @@ namespace roboptim
       : manifold_(manifold)
     {}
 
-    template <typename Fake = void>
-    mnf::Manifold& getManifold() const;
+    mnf::Manifold& getManifold() const
+    {return this->manifold_;}
   };
 
   template<class T>

--- a/include/roboptim/core/manifold-map/decorator/problem-on-manifold.hxx
+++ b/include/roboptim/core/manifold-map/decorator/problem-on-manifold.hxx
@@ -34,10 +34,5 @@ namespace roboptim
   {
   }
 
-  template <>
-  mnf::Manifold& IsAProblemOnManifold::getManifold<void>() const
-  {
-    return this->manifold_;
-  }
 }
 #endif //!ROBOPTIM_CORE_MANIFOLD_MAP_DECORATOR_PROBLEM_ON_MANIFOLD_HXX

--- a/tests/problem-factory.cc
+++ b/tests/problem-factory.cc
@@ -266,9 +266,62 @@ BOOST_AUTO_TEST_CASE_TEMPLATE (manifold_factory_test, T, functionTypes_t)
 
   factory.setObjective(cnstr3, prod2, restricted, restrictions);
 
+  std::vector<std::pair<double, double>> bounds;
+
+  {
+    bounds.clear();
+    for(int i = 0; i < 41; ++i)
+      {
+	bounds.push_back(std::make_pair(-2.0, 2.0));
+      }
+    factory.addArgumentBounds(r42, bounds);
+  }
+  {
+    bounds.clear();
+    for(int i = 0; i < 39; ++i)
+      {
+	bounds.push_back(std::make_pair(-3.0, 3.0));
+      }
+    factory.addArgumentBounds(r39, bounds);
+  }
+
   roboptim::ProblemOnManifold<problem_t>* manifoldProblem = factory.getProblem();
 
   BOOST_CHECK(manifoldProblem->getManifold().representationDim() == 22 + 42 + 39);
+
+  size_t i = 0;
+
+  for(; i < manifoldProblem->argumentBounds().size(); ++i)
+    {
+      std::cout << "[" << i << "] "
+		<< manifoldProblem->argumentBounds()[i].first
+		<< " "
+		<< manifoldProblem->argumentBounds()[i].second
+		<< std::endl;
+    }
+
+  i = 0;
+
+  for (; i < 22; ++i)
+    {
+      BOOST_CHECK(manifoldProblem->argumentBounds()[i].first == -Func::infinity());
+      BOOST_CHECK(manifoldProblem->argumentBounds()[i].second == Func::infinity());
+    }
+
+  for (; i < 22 + 39; ++i)
+    {
+      BOOST_CHECK(manifoldProblem->argumentBounds()[i].first == -3);
+      BOOST_CHECK(manifoldProblem->argumentBounds()[i].second == 3);
+    }
+
+  for (; i < 22 + 39 + 41; ++i)
+    {
+      BOOST_CHECK(manifoldProblem->argumentBounds()[i].first == -2);
+      BOOST_CHECK(manifoldProblem->argumentBounds()[i].second == 2);
+    }
+
+  BOOST_CHECK(manifoldProblem->argumentBounds()[i].first == -Func::infinity());
+  BOOST_CHECK(manifoldProblem->argumentBounds()[i].second == Func::infinity());
 
   delete manifoldProblem;
 }


### PR DESCRIPTION
Previously, there was no easy way to add bounds on arguments from a manifold (that is, to limit the value taken by a point on this manifold), and you had to keep track of the manifold's position in the global manifold to input those bounds.
Now, you can bound those values by referencing the manifold on which they are defined. 
